### PR TITLE
Build: update cmake minimum version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	endif()
 endif()
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
cmake ABI compatibility with cmake <3.5 has been removed in cmake 4. Compatibility with cmake <3.10 is deprecated and soon to be removed. Thus set 3.10 minimum version. This is available in the vast majority of current linux distributions, as well as other platforms.

Analogous to https://github.com/KhronosGroup/OpenCOLLADA/pull/664, but i have little hope it'd be merged upstream (upstream looks somewhat dead). We have this fork in `nixpkgs` to build blender, and it has started failing to cmake 4. Figured i'd upstream the patch.